### PR TITLE
Hide from pdf and epub, use data:image

### DIFF
--- a/themes/quire-starter-theme/layouts/entry/single.html
+++ b/themes/quire-starter-theme/layouts/entry/single.html
@@ -39,7 +39,7 @@ a single image or object needs to be featured prominently.\
   >
     <a
     id="toggleFullscreen" 
-    class="leaflet-control-fullscreen-button leaflet-bar-part" 
+    class="remove-from-epub leaflet-control-fullscreen-button leaflet-bar-part" 
     href="#" 
     title="View Fullscreen" 
     style="outline: none;">
@@ -54,7 +54,7 @@ a single image or object needs to be featured prominently.\
         {{ range where $.Site.Data.objects.object_list "id" "eq" .id }}
         <div class="quire-entry__image__group-container">
           {{ if gt (len .figure) 1 -}}
-          {{ if ne $.Site.Params.pdf true }}
+          {{ if ne $.Site.Params.pdf true }} 
         <button class="remove-from-epub quire-image-control quire-image-control--prev-image" id="prev-image" title="Previous image"></button>
         <button class="remove-from-epub quire-image-control quire-image-control--next-image" id="next-image" title="Next image"></button>
           {{ end }}

--- a/themes/quire-starter-theme/source/css/components/quire-deepzoom.scss
+++ b/themes/quire-starter-theme/source/css/components/quire-deepzoom.scss
@@ -156,13 +156,16 @@ div.leaflet-control {
     a {
       background-position: top;
       box-shadow: none;
-      background-image: url("../img/fullscreen-leaflet.png");
+      background-image: $fullscreen-button-img;
       &.fullscreen {
         background-position-y: bottom;
       }
       &:hover {
         background-color: transparent;
       }
+    }
+    @media print {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Hi @naeluh. In working on the PDF and EPUB outputs I made a couple small tweaks to the new fullscreen control. First, I removed it from those two output formats. Second, I noticed url for the .png icon background image wasn't resolving in the PDF, and even though that didn't matter once I removed it, I wend ahead and replaced the .png with a `data:image` version we had previously defined as `$fullscreen-button-img`. This is consistent with how you handles the prev and next arrows for the image viewer.